### PR TITLE
fix(rkr): fix bug Running Karp Rabin Greedy String Tiling algorithm

### DIFF
--- a/src/main/kotlin/org/danilopianini/plagiarismdetector/detector/PlagiarismDetector.kt
+++ b/src/main/kotlin/org/danilopianini/plagiarismdetector/detector/PlagiarismDetector.kt
@@ -17,6 +17,7 @@ interface Match
  * An interface modeling a comparison result object.
  */
 interface ComparisonResult<out M : Match> {
+
     /**
      * The score of similarity, expressed as a value between 0 and 1.
      */

--- a/src/main/kotlin/org/danilopianini/plagiarismdetector/detector/technique/tokenization/BaseGreedyStringTiling.kt
+++ b/src/main/kotlin/org/danilopianini/plagiarismdetector/detector/technique/tokenization/BaseGreedyStringTiling.kt
@@ -25,6 +25,11 @@ typealias MaximalMatches = Map<Int, List<TokenMatch>>
 typealias MarkedTokens = Pair<Set<Token>, Set<Token>>
 
 /**
+ * Simply, a mutable [MarkedTokens].
+ */
+typealias MutableMarkedTokens = Pair<MutableSet<Token>, MutableSet<Token>>
+
+/**
  * This is an abstract base implementation of the common code for Greedy String Tiling algorithm's family.
  * [Here](https://bit.ly/3f3qzED) you can find the paper in which were originally described.
  */
@@ -50,7 +55,10 @@ abstract class BaseGreedyStringTiling(
         }
 
     /**
-     * Top level algorithm: it executes the logic of the algorithm.
+     * Top level algorithm: it executes the logic of the algorithm, returning a set of [TokenMatch].
+     * According to the terminology of the paper, this function returns the set of discovered tiles,
+     * i.e. the one-to-one association of a subsequence of [Tokens] of the pattern with a matching
+     * subsequence of [Tokens] from the text.
      */
     protected abstract fun runAlgorithm(pattern: TokenizedSource, text: TokenizedSource): Set<TokenMatch>
 
@@ -67,30 +75,24 @@ abstract class BaseGreedyStringTiling(
     ): Pair<MaximalMatches, Int>
 
     /**
-     * Selects, from [matches] of the given [matchLength] which are not occluded
-     * (i.e. are not contained in [marked]), marking the corresponding tokens.
-     * According to the terminology of the paper, this function returns the set of
-     * discovered tiles, i.e. the one-to-one association of a subsequence of [Tokens]
-     * of the pattern with a matching subsequence of [Tokens] from the text.
-     * It corresponds to the `markarrays()` function of the paper.
+     * If the given [match] is not occluded marks the tokens which is composed of
+     * and add it to [tiles]. Otherwise, is executed the [elseBlock] which is, by
+     * default, a function that does nothing.
+     * This is the heart of the `markarrays()` function of the paper.
      */
-    protected fun markMatches(
-        marked: MarkedTokens,
-        matches: MaximalMatches,
-        matchLength: Int,
-    ): Pair<Set<TokenMatch>, MarkedTokens> {
-        val tiles = mutableSetOf<TokenMatch>()
-        val myMarked = Pair(marked.first.toMutableSet(), marked.second.toMutableSet())
-        matches[matchLength]?.let {
-            it.forEach { match ->
-                if (isNotOccluded(match, myMarked)) {
-                    match.pattern.second.forEach(myMarked.first::add)
-                    match.text.second.forEach(myMarked.second::add)
-                    tiles.add(match)
-                }
-            }
+    protected fun addToTilesOrElse(
+        match: TokenMatch,
+        marked: MutableMarkedTokens,
+        tiles: MutableSet<TokenMatch>,
+        elseBlock: () -> Unit = { }
+    ) {
+        if (isNotOccluded(match, marked)) {
+            match.pattern.second.forEach(marked.first::add)
+            match.text.second.forEach(marked.second::add)
+            tiles.add(match)
+        } else {
+            elseBlock()
         }
-        return Pair(tiles, myMarked)
     }
 
     /**
@@ -119,7 +121,7 @@ abstract class BaseGreedyStringTiling(
     /**
      * Update the marked tokens with those from the specified [other] collection.
      */
-    protected fun Pair<MutableSet<Token>, MutableSet<Token>>.addAll(other: MarkedTokens) {
+    protected fun MutableMarkedTokens.addAll(other: MarkedTokens) {
         this.first.addAll(other.first)
         this.second.addAll(other.second)
     }

--- a/src/main/kotlin/org/danilopianini/plagiarismdetector/detector/technique/tokenization/GreedyStringTiling.kt
+++ b/src/main/kotlin/org/danilopianini/plagiarismdetector/detector/technique/tokenization/GreedyStringTiling.kt
@@ -1,7 +1,6 @@
 package org.danilopianini.plagiarismdetector.detector.technique.tokenization
 
 import org.danilopianini.plagiarismdetector.analyzer.representation.TokenizedSource
-import org.danilopianini.plagiarismdetector.analyzer.representation.token.Token
 
 /**
  * Basic thread-safe implementation of Greedy String Tiling algorithm.
@@ -16,14 +15,12 @@ class GreedyStringTiling(
 
     override fun runAlgorithm(pattern: TokenizedSource, text: TokenizedSource): Set<TokenMatch> {
         val tiles = mutableSetOf<TokenMatch>()
-        val marked = Pair(mutableSetOf<Token>(), mutableSetOf<Token>())
+        val marked: MutableMarkedTokens = Pair(mutableSetOf(), mutableSetOf())
         val matches: MutableMap<Int, List<TokenMatch>> = mutableMapOf()
         do {
             val (selectedMatches, largestMatch) = searchMatches(pattern, text, marked, minimumMatchLength)
             matches.putAll(selectedMatches)
-            val (newTiles, newMarked) = markMatches(marked, matches, largestMatch)
-            tiles.addAll(newTiles)
-            marked.addAll(newMarked)
+            matches[largestMatch]?.forEach { addToTilesOrElse(it, marked, tiles) }
         } while (largestMatch != minimumMatchLength)
         return tiles
     }

--- a/src/main/kotlin/org/danilopianini/plagiarismdetector/detector/technique/tokenization/RKRGreedyStringTiling.kt
+++ b/src/main/kotlin/org/danilopianini/plagiarismdetector/detector/technique/tokenization/RKRGreedyStringTiling.kt
@@ -3,6 +3,8 @@ package org.danilopianini.plagiarismdetector.detector.technique.tokenization
 import org.danilopianini.plagiarismdetector.analyzer.representation.TokenizedSource
 import org.danilopianini.plagiarismdetector.analyzer.representation.token.Token
 import java.util.TreeMap
+import kotlin.math.max
+import kotlin.math.min
 
 /** A map with (hash value, set of sequences with that hash value). */
 typealias HashTable = Map<Int, Set<Tokens>>
@@ -24,20 +26,16 @@ class RKRGreedyStringTiling(
         val marked = Pair(mutableSetOf<Token>(), mutableSetOf<Token>())
         while (searchLength != 0) {
             val (matches, lmax) = searchMatches(pattern, text, marked, searchLength)
-            matches.toSortedMap(Comparator.reverseOrder()).forEach {
-                val (newTiles, newMarked) = markMatches(marked, matches, it.key)
-                tiles.addAll(newTiles)
-                marked.addAll(newMarked)
-            }
+            markMatches(tiles, marked, matches)
             searchLength = updateSearchLength(lmax)
         }
         return tiles
     }
 
-    private fun updateSearchLength(lmax: Int): Int {
+    private fun updateSearchLength(actualSearchLength: Int): Int {
         return when {
-            lmax > 2 * minimumMatchLength -> lmax / 2
-            lmax > minimumMatchLength -> minimumMatchLength
+            actualSearchLength > 2 * minimumMatchLength -> actualSearchLength / 2
+            actualSearchLength > minimumMatchLength -> minimumMatchLength
             else -> 0
         }
     }
@@ -52,6 +50,10 @@ class RKRGreedyStringTiling(
         return secondPhase(pattern, text, marked, searchLength, hashTable)
     }
 
+    /**
+     * Iterates the [text] tokens hashing the subsequences of length
+     * [searchLength], returning the resulting [HashTable].
+     */
     private fun firstPhase(text: TokenizedSource, marked: MarkedTokens, searchLength: Int): HashTable {
         val hashTable: MutableMap<Int, MutableSet<Tokens>> = mutableMapOf()
         phase(text.representation, marked.second, searchLength) { tokens ->
@@ -63,6 +65,10 @@ class RKRGreedyStringTiling(
         return hashTable
     }
 
+    /**
+     * Iterates the [pattern] looking for matches in [text] of length [searchLength].
+     * [HashTable] is used to skip sequence of tokens with different hash value.
+     */
     private fun secondPhase(
         pattern: TokenizedSource,
         text: TokenizedSource,
@@ -76,23 +82,22 @@ class RKRGreedyStringTiling(
         phase(patternTokens, marked.first, searchLength) { tokens ->
             val searched = tokens.take(searchLength)
             val hashValue = hashValueOf(searched)
-            hashTable[hashValue]?.let {
-                it.filter { candidates -> searched areEqualsTo candidates }
-                    .forEach { matching ->
-                        val ptnTokensFromLastChecked = patternTokens.drop(patternTokens.indexOf(searched.last()) + 1)
-                        val txtTokensFromLastChecked = textTokens.drop(textTokens.indexOf(matching.last()) + 1)
-                        val otherMatches = scan(ptnTokensFromLastChecked, txtTokensFromLastChecked, marked)
-                        val patternMatches = searched.toList() + otherMatches.first
-                        val textMatches = matching.toList() + otherMatches.second
-                        val matchLen = patternMatches.count()
-                        if (matchLen > 2 * searchLength) {
-                            return searchMatches(pattern, text, marked, matchLen)
-                        } else {
-                            val match = TokenMatchImpl(Pair(pattern, patternMatches), Pair(text, textMatches), matchLen)
-                            matches[matchLen]?.add(match) ?: matches.put(matchLen, mutableListOf(match))
-                        }
+            hashTable[hashValue]
+                ?.filter { candidates -> candidates areEqualsTo searched }
+                ?.forEach { matching ->
+                    val ptnTokensFromLastChecked = patternTokens.drop(patternTokens.indexOf(searched.last()) + 1)
+                    val txtTokensFromLastChecked = textTokens.drop(textTokens.indexOf(matching.last()) + 1)
+                    val otherMatches = scan(ptnTokensFromLastChecked, txtTokensFromLastChecked, marked)
+                    val patternMatches = searched.toList() + otherMatches.first
+                    val textMatches = matching.toList() + otherMatches.second
+                    val matchLen = patternMatches.count()
+                    if (matchLen > 2 * searchLength) {
+                        return searchMatches(pattern, text, marked, matchLen)
+                    } else {
+                        val match = TokenMatchImpl(Pair(pattern, patternMatches), Pair(text, textMatches), matchLen)
+                        matches[matchLen]?.add(match) ?: matches.put(matchLen, mutableListOf(match))
                     }
-            }
+                }
         }
         return Pair(matches, searchLength)
     }
@@ -107,6 +112,11 @@ class RKRGreedyStringTiling(
         }
     }
 
+    /**
+     * Computes the hash value for the given sequence of [tokens].
+     * Note that the computation of the modulus is avoided by using the implicit modular
+     * arithmetic given by the hardware that forgets carries in integer operations.
+     */
     private fun hashValueOf(tokens: Tokens): Int {
         var hashValue = 0
         tokens.forEach {
@@ -115,20 +125,72 @@ class RKRGreedyStringTiling(
         return hashValue
     }
 
-    private infix fun Tokens.areEqualsTo(others: Tokens): Boolean {
-        if (count() != others.count()) {
-            return false
-        }
-        repeat(count()) {
-            if (this.elementAt(it).type != others.elementAt(it).type) {
-                return false
-            }
-        }
-        return true
-    }
+    /**
+     * Returns if this sequence is equals to [other] in terms of their types.
+     */
+    private infix fun Tokens.areEqualsTo(other: Tokens): Boolean =
+        if (this.count() == other.count()) zip(other).all { it.first.type == it.second.type } else false
 
+    /**
+     * Computes the distance between the first of [tokens] and the first unmarked one.
+     * If no unmarked tokens are found before the end of the sequence, its length is returned.
+     */
     private fun distanceToNextTile(tokens: Tokens, marked: Set<Token>): Int {
         val result = tokens.indexOfFirst(marked::contains)
         return if (result == -1) tokens.count() else result
     }
+
+    /**
+     * Marks and add to [tiles] all the unmarked [matches] given in input.
+     */
+    private fun markMatches(tiles: MutableSet<TokenMatch>, marked: MutableMarkedTokens, matches: MaximalMatches) {
+        val myMatches = matches.toMutableMap()
+        while (myMatches.isNotEmpty()) {
+            val maxMatch = myMatches.keys.max()
+            myMatches.getValue(maxMatch).forEach {
+                addToTilesOrElse(it, marked, tiles) {
+                    with(unmarkedPartOfMatch(it, marked)) {
+                        if (length >= minimumMatchLength) {
+                            myMatches[length] = myMatches[length]?.plus(this) ?: mutableListOf(this)
+                        }
+                    }
+                }
+            }
+            myMatches.remove(maxMatch)
+        }
+    }
+
+    /**
+     * Returns a [TokenMatch] which is the unmarked (i.e. not contained in
+     * [marked]) part remaining of the [match] given in input.
+     */
+    private fun unmarkedPartOfMatch(match: TokenMatch, marked: MarkedTokens): TokenMatch {
+        val (firstUnmarkedOfPtn, lastUnmarkedOfPtn) = indexesOfUnmarked(match.pattern.second, marked.first)
+        val (firstUnmarkedOfTxt, lastUnmarkedOfTxt) = indexesOfUnmarked(match.text.second, marked.second)
+        val start = max(firstUnmarkedOfPtn, firstUnmarkedOfTxt)
+        val stop = min(lastUnmarkedOfPtn, lastUnmarkedOfTxt)
+        return subMatch(start, stop + 1, match)
+    }
+
+    /**
+     * Returns a [Pair] with, respectively, the initial and final index of unmarked [tokens].
+     */
+    private fun indexesOfUnmarked(tokens: List<Token>, marked: Set<Token>): Pair<Int, Int> = with(tokens) {
+        Pair(indexOfFirst { it !in marked }, indexOfLast { it !in marked })
+    }
+
+    /**
+     * Returns a new [TokenMatch] created from [match] one containing matches between
+     * the specified [fromIndex] (inclusive) and [toIndex] (exclusive).
+     */
+    private fun subMatch(fromIndex: Int, toIndex: Int, match: TokenMatch): TokenMatch =
+        if (fromIndex < 0 || toIndex <= fromIndex) {
+            TokenMatchImpl(Pair(match.pattern.first, emptyList()), Pair(match.text.first, emptyList()), 0)
+        } else {
+            TokenMatchImpl(
+                Pair(match.pattern.first, match.pattern.second.subList(fromIndex, toIndex)),
+                Pair(match.text.first, match.text.second.subList(fromIndex, toIndex)),
+                toIndex - fromIndex
+            )
+        }
 }

--- a/src/main/kotlin/org/danilopianini/plagiarismdetector/detector/technique/tokenization/TokenMatch.kt
+++ b/src/main/kotlin/org/danilopianini/plagiarismdetector/detector/technique/tokenization/TokenMatch.kt
@@ -8,6 +8,7 @@ import org.danilopianini.plagiarismdetector.detector.Match
  * A match between two [TokenizedSource].
  */
 interface TokenMatch : Match {
+
     /**
      * The matching [Token]s in the pattern, i.e. the shorter [TokenizedSource].
      */

--- a/src/test/kotlin/org/danilopianini/plagiarismdetector/detector/TokenBasedPlagiarismDetectorTest.kt
+++ b/src/test/kotlin/org/danilopianini/plagiarismdetector/detector/TokenBasedPlagiarismDetectorTest.kt
@@ -18,6 +18,8 @@ class TokenBasedPlagiarismDetectorTest : FunSpec() {
         private const val INVENTORY_FILE_NAME = "InventoryControllerImpl.java"
         private const val EDITOR_FILE_NAME = "EditorBoard.java"
         private const val PLAYER_FILE_NAME = "PlayerImplTest.java"
+        private const val VALIDATOR_FILE_NAME = "ValidatorTest.java"
+        private const val LEVEL_STRATEGY_FILE = "StandardLevelIncreaseStrategyTest.java"
     }
     private val logger = LoggerFactory.getLogger(this::class.java)
     private val analyzer = JavaTokenizationAnalyzer()
@@ -39,6 +41,12 @@ class TokenBasedPlagiarismDetectorTest : FunSpec() {
             val playerFile = File(ClassLoader.getSystemResource(PLAYER_FILE_NAME).toURI())
             val editorFile = File(ClassLoader.getSystemResource(EDITOR_FILE_NAME).toURI())
             runDetection(Pair(playerFile, editorFile))
+        }
+
+        test("Testing tokenization detection between non-similar sources/3") {
+            val file1 = File(ClassLoader.getSystemResource(VALIDATOR_FILE_NAME).toURI())
+            val file2 = File(ClassLoader.getSystemResource(LEVEL_STRATEGY_FILE).toURI())
+            runDetection(Pair(file1, file2))
         }
     }
 

--- a/src/test/resources/StandardLevelIncreaseStrategyTest.java
+++ b/src/test/resources/StandardLevelIncreaseStrategyTest.java
@@ -1,0 +1,33 @@
+package rogue.model.creature;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Test class
+ * @see https://github.com/DanySK/Student-Project-OOP20-Chiarini-Pezzi-Quarneti-Tassinari-rogue/blob/main/src/test/java/rogue/model/creature/StandardLevelIncreaseStrategyTest.java
+ */
+public class StandardLevelIncreaseStrategyTest {
+
+    private static final int LEVEL_12 = 12;
+    private static final int EXP_LEVEL_12 = 789;
+    private static final int EXP_LEVEL_20 = 12_000;
+    private static final int LEVEL_20 = 20;
+    private static final int EXP_LEVEL_2 = 7;
+    private static final int LEVEL_2 = 2;
+    private LevelIncreaseStrategy strategy;
+
+    @org.junit.Before
+    public void init() {
+        strategy = new StandardLevelIncreaseStrategy();
+    }
+
+    @Test
+    public void test() {
+        assertEquals(LEVEL_2, strategy.getLevel(EXP_LEVEL_2));
+        assertEquals(LEVEL_20, strategy.getLevel(EXP_LEVEL_20));
+        assertEquals(LEVEL_12, strategy.getLevel(EXP_LEVEL_12));
+    }
+
+}

--- a/src/test/resources/ValidatorTest.java
+++ b/src/test/resources/ValidatorTest.java
@@ -1,0 +1,48 @@
+package jhaturanga.test.model.validator;
+
+import static jhaturanga.model.user.validators.StringValidatorImpl.ValidationResult.CORRECT;
+import static jhaturanga.model.user.validators.StringValidatorImpl.ValidationResult.EMPTY;
+import static jhaturanga.model.user.validators.StringValidatorImpl.ValidationResult.TOO_LONG;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jhaturanga.model.user.validators.FunctionConcatenator;
+import jhaturanga.model.user.validators.StringValidatorImpl;
+import jhaturanga.model.user.validators.StringValidatorImpl.ValidationResult;
+
+/**
+ * Test class
+ * @see https://github.com/DanySK/Student-Project-OOP20-Andruccioli-Mazzoli-Patriti-Scolari-Jhaturanga/blob/main/src/test/java/jhaturanga/test/model/validator/ValidatorTest.java
+ */
+class ValidatorTest {
+
+    private FunctionConcatenator<String, ValidationResult> v;
+
+    @BeforeEach
+    void initialize() {
+        v = new StringValidatorImpl();
+    }
+
+    @Test
+    void emptyBuild() {
+        assertSame(CORRECT, v.create().apply("try1"));
+    }
+
+    @Test
+    void addOne() {
+        v.add(s -> s.length() == 0 ? CORRECT : EMPTY);
+        assertSame(CORRECT, v.create().apply(""));
+        assertSame(EMPTY, v.create().apply("try2"));
+    }
+
+    @Test
+    void addTwo() {
+        v.add(s -> s.length() != 0 ? CORRECT : EMPTY).add(s -> s.length() < 3 ? CORRECT : TOO_LONG);
+        assertSame(CORRECT, v.create().apply("tr")); // OK
+        assertSame(EMPTY, v.create().apply(""));
+        assertSame(TOO_LONG, v.create().apply("tryError"));
+    }
+
+}


### PR DESCRIPTION
This PR fixes a bug in the RKRGST algorithm used for detection which not considered leftover unmarked tokens of an occluded tile that were longer than the minimum search length. A new test is introduced to cover this case.