### PR TITLE
refactor(cli)!: move to new syntax to specify corpus and submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,26 +66,22 @@ Usage: cli submission [OPTIONS]
 
   Submission options.
 
-Options to specify for search by criteria:
-  --service [github|bitbucket]  The hosting services where are stored the
-                                repositories, possibly separated by commas.
-  --user TEXT                   The usernames of the repos owners, possibly
-                                separated by commas.
-  --repository-name TEXT        The names of the searched repositories,
-                                possibly separated by commas.
-
 Options:
-  --url VALUE  The URL addresses of the repositories to be retrieved, possibly
-               separated by commas.
-  -h, --help   Show this message and exit
+  --service TEXT  A (list of) triple, possibly separated by commas, containing
+                  a supported hostingservice (github|bitbucket), the owner of
+                  the repo and an optional repository name to search,
+                  formatted: like this: `service-name:owner[/repo-name]`.
+  --url VALUE     The URL addresses of the repositories to be retrieved,
+                  possibly separated by commas.
+  -h, --help      Show this message and exit
 ```
 
-For example:
+For example (equivalent for `corpus` subcommand):
 - to search by multiple URL:
   ```bash
   submission --url https://github.com/unibo-oop-projects/Student-Project-OOP-21-Bragari-Mennuti-Violani-Volfgit,https://github.com/unibo-oop-projects/Student-Project-OOP21-Bianchi-Ciccioni-stubborn
   ```
-- to search according to the following criteria: all projects with name `oop` owned by `danysk` and `unibo-oop-projects` from GitHub and Bitbucket:
+- to search according to the following criteria: all GitHub repos owned by `unibo-oop-projects` and the Bitbucket repos named `oop` owned by `danysk`:
   ```bash
-  submission --repository-name oop --user danysk,unibo-oop-projects --service github,bitbucket
+  submission --service github:unibo-oop-projects,bitbucket:danysk/oop
   ```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Usage: cli submission [OPTIONS]
 
 Options:
   --service TEXT  A (list of) triple, possibly separated by commas, containing
-                  a supported hostingservice (github|bitbucket), the owner of
+                  a supported hosting service (github|bitbucket), the owner of
                   the repo and an optional repository name to search,
                   formatted: like this: `service-name:owner[/repo-name]`.
   --url VALUE     The URL addresses of the repositories to be retrieved,

--- a/src/main/kotlin/org/danilopianini/plagiarismdetector/input/cli/CLIConfigurator.kt
+++ b/src/main/kotlin/org/danilopianini/plagiarismdetector/input/cli/CLIConfigurator.kt
@@ -66,7 +66,7 @@ class CLIConfigurator(private val output: Output) : RunConfigurator {
                 )
         }
     } catch (e: IllegalStateException) {
-        output.logInfo("Both `corpus` and `provider` subcommands are required ($e)")
+        output.logInfo("Both `corpus` and `submission` subcommands are required ($e)")
         exitProcess(1)
     }
 

--- a/src/main/kotlin/org/danilopianini/plagiarismdetector/input/cli/provider/ProviderCommand.kt
+++ b/src/main/kotlin/org/danilopianini/plagiarismdetector/input/cli/provider/ProviderCommand.kt
@@ -77,7 +77,7 @@ sealed class ProviderCommand(
     companion object {
         private const val MORE_ARGS_HELP = "possibly separated by commas"
         private const val URL_HELP_MSG = "The URL addresses of the repositories to be retrieved, $MORE_ARGS_HELP."
-        private const val SERVICE_HELP_MSG = "A (list of) triple, $MORE_ARGS_HELP, containing a supported hosting" +
+        private const val SERVICE_HELP_MSG = "A (list of) triple, $MORE_ARGS_HELP, containing a supported hosting " +
             "service (github|bitbucket), the owner of the repo and an optional repository name to search, formatted: " +
             "like this: `service-name:owner[/repo-name]`."
     }

--- a/src/main/kotlin/org/danilopianini/plagiarismdetector/input/cli/provider/ProviderCommand.kt
+++ b/src/main/kotlin/org/danilopianini/plagiarismdetector/input/cli/provider/ProviderCommand.kt
@@ -36,14 +36,14 @@ sealed class ProviderCommand(
         }
 
     /**
-     * The repository [URL]s to use.
+     * The repository [URL]s to use to retrieve searched repos.
      */
     val url: List<URL>? by option(help = URL_HELP_MSG)
         .convert { URL(it) }
         .split(",")
 
     /**
-     * Gets a sequence of configured [SearchCriteria], with all combinations of given options.
+     * Gets a [Sequence] of configured [SearchCriteria] to use to retrieve searched repos.
      */
     val criteria: Sequence<SearchCriteria<*, *>>? by lazy {
         if (service != null) {

--- a/src/main/kotlin/org/danilopianini/plagiarismdetector/input/cli/provider/ProviderCommand.kt
+++ b/src/main/kotlin/org/danilopianini/plagiarismdetector/input/cli/provider/ProviderCommand.kt
@@ -30,7 +30,7 @@ sealed class ProviderCommand(
         .validate {
             it.forEach {
                 require(it.contains(Regex("\\w+:\\w+(/.*)?"))) {
-                    "$it is not compliant to `service-name:owner[/repo-query]` format."
+                    "$it is not compliant to `service-name:owner[/repo-name]` format."
                 }
             }
         }
@@ -77,6 +77,8 @@ sealed class ProviderCommand(
     companion object {
         private const val MORE_ARGS_HELP = "possibly separated by commas"
         private const val URL_HELP_MSG = "The URL addresses of the repositories to be retrieved, $MORE_ARGS_HELP."
-        private const val SERVICE_HELP_MSG = "The hosting services where are stored the repositories, $MORE_ARGS_HELP."
+        private const val SERVICE_HELP_MSG = "A (list of) triple, $MORE_ARGS_HELP, containing a supported hosting" +
+            "service (github|bitbucket), the owner of the repo and an optional repository name to search, formatted: " +
+            "like this: `service-name:owner[/repo-name]`."
     }
 }

--- a/src/main/kotlin/org/danilopianini/plagiarismdetector/input/cli/provider/ProviderCommand.kt
+++ b/src/main/kotlin/org/danilopianini/plagiarismdetector/input/cli/provider/ProviderCommand.kt
@@ -2,11 +2,8 @@ package org.danilopianini.plagiarismdetector.input.cli.provider
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.PrintMessage
-import com.github.ajalt.clikt.parameters.groups.OptionGroup
-import com.github.ajalt.clikt.parameters.groups.cooccurring
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.split
 import com.github.ajalt.clikt.parameters.options.validate
 import org.danilopianini.plagiarismdetector.utils.BitBucket
@@ -28,25 +25,48 @@ sealed class ProviderCommand(
     help: String,
 ) : CliktCommand(name = name, help = help) {
 
-    private val criteriaOptions by CriteriaOptions()
-        .cooccurring()
+    private val service by option(help = SERVICE_HELP_MSG)
+        .split(",")
+        .validate {
+            it.forEach {
+                require(it.contains(Regex("\\w+:\\w+(/.*)?"))) {
+                    "$it is not compliant to `service-name:owner[/repo-query]` format."
+                }
+            }
+        }
 
     /**
      * The repository [URL]s to use.
      */
-    val url by option(help = URL_HELP_MSG)
+    val url: List<URL>? by option(help = URL_HELP_MSG)
         .convert { URL(it) }
         .split(",")
 
     /**
-     * The [SearchCriteria] to use.
+     * Gets a sequence of configured [SearchCriteria], with all combinations of given options.
      */
-    val criteria by lazy {
-        criteriaOptions?.criteria
+    val criteria: Sequence<SearchCriteria<*, *>>? by lazy {
+        if (service != null) {
+            val services = service!!.map { it.substringBefore(":") }.map(SupportedOptions::serviceBy)
+            val owners = service!!.map { it.substringAfter(":").substringBefore("/") }
+            val repoNames = service!!.map { it.substringAfter("/", "") }
+            services.zip(owners)
+                .zip(repoNames) { a, b -> Triple(a.first, a.second, b) }
+                .map { byCriteria(it.first, it.second, it.third) }
+                .asSequence()
+        } else {
+            null
+        }
     }
 
+    private fun byCriteria(service: HostingService, user: String, repoName: String): SearchCriteria<*, *> =
+        when (service) {
+            GitHub -> ByGitHubUser(user).let { if (repoName.isNotEmpty()) ByGitHubName(repoName, it) else it }
+            BitBucket -> ByBitbucketUser(user).let { if (repoName.isNotEmpty()) ByBitbucketName(repoName, it) else it }
+        }
+
     override fun run() {
-        if (url == null && criteriaOptions == null) {
+        if (url == null && service == null) {
             throw PrintMessage(
                 message = "At least one between `url` and `criteria` must be valued in `$commandName` command.",
                 error = true
@@ -58,46 +78,5 @@ sealed class ProviderCommand(
         private const val MORE_ARGS_HELP = "possibly separated by commas"
         private const val URL_HELP_MSG = "The URL addresses of the repositories to be retrieved, $MORE_ARGS_HELP."
         private const val SERVICE_HELP_MSG = "The hosting services where are stored the repositories, $MORE_ARGS_HELP."
-    }
-
-    private inner class CriteriaOptions : OptionGroup("Options to specify for search by criteria") {
-
-        private val service by option(help = SERVICE_HELP_MSG)
-            .split(",")
-            .required()
-            .validate {
-                it.forEach {
-                    require(it.contains(Regex("\\w+:\\w+(\\/.*)?"))) {
-                        "must be `service-name:owner[/repo-query]` formatted"
-                    }
-                }
-            }
-
-        /**
-         * Gets a sequence of configured [SearchCriteria], with all combinations of given options.
-         */
-        val criteria: Sequence<SearchCriteria<*, *>> by lazy {
-            val services = service.map { it.substringBefore(":") }.map(SupportedOptions::serviceBy)
-            val owners = service.map { it.substringAfter(":").substringBefore("/") }
-            val repoNames = service.map { it.substringAfter("/", "") }
-            services.zip(owners)
-                .zip(repoNames) { a, b -> Triple(a.first, a.second, b) }
-                .map { byCriteria(it.first, it.second, it.third) }
-                .asSequence()
-        }
-
-        private fun byCriteria(service: HostingService, user: String, repositoryName: String): SearchCriteria<*, *> =
-            when (service) {
-                GitHub -> {
-                    ByGitHubUser(user).run {
-                        if (repositoryName.isNotEmpty()) ByGitHubName(repositoryName, this) else this
-                    }
-                }
-                BitBucket -> {
-                    ByBitbucketUser(user).run {
-                        if (repositoryName.isNotEmpty()) ByBitbucketName(repositoryName, this) else this
-                    }
-                }
-            }
     }
 }

--- a/src/test/kotlin/org/danilopianini/plagiarismdetector/input/cli/CLIConfiguratorTest.kt
+++ b/src/test/kotlin/org/danilopianini/plagiarismdetector/input/cli/CLIConfiguratorTest.kt
@@ -35,10 +35,7 @@ class CLIConfiguratorTest : FunSpec() {
             BitbucketProvider.connectAnonymously()
         }
 
-        test(
-            "Launching CLI configuration with multiple users which are not" +
-                " present in both services should not throw an exception"
-        ) {
+        test("Launching CLI configuration user do not exists should throw exception") {
             val args = listOf(
                 "--output-dir",
                 tempdir().path,
@@ -46,14 +43,10 @@ class CLIConfiguratorTest : FunSpec() {
                 "--url",
                 "https://github.com/DanySK/code-plagiarism-detector",
                 "corpus",
-                "--repository-name",
-                "oop",
-                "--user",
-                "danysk,unibo-oop-projects",
                 "--service",
-                "github,bitbucket"
+                "github:a-non-existing-user",
             )
-            configurator(args)
+            shouldThrow<java.lang.IllegalStateException> { configurator(args) }
         }
 
         test("If `corpus` or `provider` command is not provided, the process exits with an error message") {


### PR DESCRIPTION
This PR changes the syntax to specify corpus and submission criteria. 

The new syntax allows specifying a (list of) triple, possibly separated by commas, containing a supported hosting service (github|bitbucket), the owner of the repo, and an optional repository name to search, formatted like this: `service-name:owner[/repo-name]`.

For example, to search according to the following criteria: all GitHub repos owned by `unibo-oop-projects` and the Bitbucket repos named `oop` owned by `danysk`:
```
submission --service github:unibo-oop-projects,bitbucket:danysk/oop
```